### PR TITLE
ci: fix pull-request-lint job name to match required status check

### DIFF
--- a/.github/workflows/pull-request-lint.yml
+++ b/.github/workflows/pull-request-lint.yml
@@ -11,7 +11,7 @@ on:
   merge_group: {}
 jobs:
   validate:
-    name: Validate PR title
+    name: Lint PR title
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write


### PR DESCRIPTION
The ruleset requires 'Lint PR title' as a required status check, but the pull-request-lint workflow registers the check as 'Validate PR title' (the job display name). This renames the job to 'Lint PR title' to match the required check context name, which will unblock PRs that are being held by the missing check.